### PR TITLE
- Added support for shutdown command

### DIFF
--- a/pyRserve/rconn.py
+++ b/pyRserve/rconn.py
@@ -6,7 +6,7 @@ import time
 ###
 from . import rtypes
 from .rexceptions import RConnectionRefused, REvalError, PyRserveClosed
-from .rserializer import rEval, rAssign
+from .rserializer import rEval, rAssign, rShutdown
 from .rparser import rparse
 from .misc import hexString
 
@@ -94,6 +94,10 @@ class RConnector(object):
 
     def _reval(self, aString, void):
         rEval(aString, fp=self.sock, void=void)
+
+    def shutdown(self):
+        rShutdown(fp=self.sock)
+        self.close()
 
     @checkIfClosed
     def eval(self, aString, atomicArray=None, void=False):

--- a/pyRserve/rserializer.py
+++ b/pyRserve/rserializer.py
@@ -2,7 +2,7 @@
 Serializer class to convert Python objects into a binary data stream for
 sending them to Rserve.
 """
-__all__ = ['reval', 'rassign', 'rSerializeResponse']
+__all__ = ['reval', 'rassign', 'rSerializeResponse', 'rShutdown']
 
 import struct
 import os
@@ -378,6 +378,11 @@ class RSerializer(object):
         return s.finalize()
 
     @classmethod
+    def rShutdown(cls, fp=None):
+        s = cls(rtypes.CMD_shutdown, fp=fp)
+        return s.finalize()
+
+    @classmethod
     def rSerializeResponse(cls, Rexp, fp=None):
         # mainly used for unittesting
         s = cls(rtypes.CMD_RESP | rtypes.RESP_OK, fp=fp)
@@ -389,3 +394,4 @@ class RSerializer(object):
 rEval = RSerializer.rEval
 rAssign = RSerializer.rAssign
 rSerializeResponse = RSerializer.rSerializeResponse
+rShutdown = RSerializer.rShutdown


### PR DESCRIPTION
pyRserve did not implement the `CMD_shutdown` command yet. 
