### PR TITLE
Enhanced NA Handling

### DIFF
--- a/pyRserve/misc.py
+++ b/pyRserve/misc.py
@@ -48,6 +48,8 @@ def byteEncode(aString, encoding='utf-8'):
 def stringEncode(byteData, encoding='utf-8'):
     # check for __name__ not to get faked by Python2.x!
     if PY3 and type(byteData).__name__ == 'bytes':
+        if byteData == b'\xff':
+            return None
         # got a real bytes object, must be python3 !
         return byteData.decode(encoding=encoding)
     else:

--- a/pyRserve/rparser.py
+++ b/pyRserve/rparser.py
@@ -517,20 +517,20 @@ class RParser(object):
                 # For convenience reasons type-convert it into a native
                 # Python data type:
                 data = data[0]
-                if isinstance(data, (numpy.float, numpy.float64)):
+                if isinstance(data, (float, numpy.float64)):
                     # convert into native python float:
                     data = float(data)
-                elif isinstance(data, (numpy.int, numpy.int32, numpy.int64)):
+                elif isinstance(data, (int, numpy.int32, numpy.int64)):
                     # convert into native int or long, depending on value:
                     data = int(data)
-                elif isinstance(data, (numpy.complex, numpy.complex64,
+                elif isinstance(data, (complex, numpy.complex64,
                                        numpy.complex128)):
                     # convert into native python complex number:
                     data = complex(data)
-                elif isinstance(data, (numpy.string_, numpy.str_)):
+                elif isinstance(data, (numpy.string_, str)):
                     # convert into native python string:
                     data = str(data)
-                elif isinstance(data, (numpy.bool_, numpy.bool, numpy.bool8)):
+                elif isinstance(data, (bool, numpy.bool8)):
                     # convert into native python string
                     data = bool(data)
         return data

--- a/pyRserve/rparser.py
+++ b/pyRserve/rparser.py
@@ -338,6 +338,15 @@ class Lexer(object):
         numBools = self.__unpack(XT_INT, 1)[0]
         # read the actual boolean values, including padding bytes:
         raw = self.read(lexeme.dataLength - 4)
+        # Check if the array contains any NA values (encoded as \x02).
+        # If so we need to convert the 2's to None's and use a numpy
+        # array of type Object otherwise numpy will cast the None's into False's. 
+        # This is handled for us for numeric types since numpy can use it's own
+        # nan type, but here we need to help it out.
+        if 2 in raw:
+            data = numpy.frombuffer(raw[:numBools], dtype=numpy.int8).astype(numpy.object)
+            data[data==2] = None
+            return data
         data = numpy.frombuffer(raw[:numBools],
                                 dtype=numpyMap[lexeme.rTypeCode])
         return data

--- a/pyRserve/rparser.py
+++ b/pyRserve/rparser.py
@@ -344,11 +344,13 @@ class Lexer(object):
         # This is handled for us for numeric types since numpy can use it's own
         # nan type, but here we need to help it out.
         if 2 in raw:
-            data = numpy.frombuffer(raw[:numBools], dtype=numpy.int8).astype(numpy.object)
+            data = numpy.frombuffer(raw[:numBools], dtype=numpy.int8).astype(object)
             data[data==2] = None
-            return data
-        data = numpy.frombuffer(raw[:numBools],
-                                dtype=numpyMap[lexeme.rTypeCode])
+        else:
+            data = numpy.frombuffer(
+                raw[:numBools],
+                dtype=numpyMap[lexeme.rTypeCode]
+            )
         return data
 
     @fmap(XT_ARRAY_STR)

--- a/pyRserve/rserializer.py
+++ b/pyRserve/rserializer.py
@@ -283,7 +283,7 @@ class RSerializer(object):
         self._buffer.write(struct.pack(structCode, o.size))
         # Then write the boolean values themselves. Note that R expects binary
         # array data in Fortran order, so prepare this accordingly:
-        data = o.tostring(order='F')
+        data = o.tobytes(order='F')
         self._buffer.write(data)
         # Finally pad the binary data to be of a multiple of four in length:
         self._buffer.write(padLen4(data) * b'\xff')
@@ -291,14 +291,14 @@ class RSerializer(object):
         # Update the array header:
         self.__s_update_xt_array_header(startPos, rTypeCode)
 
-    @fmap(int, numpy.int32, long, numpy.int64, numpy.long, float, complex,
-          numpy.float64, numpy.complex, numpy.complex64, numpy.complex128)
+    @fmap(int, numpy.int32, long, numpy.int64, numpy.compat.long, float, complex,
+          numpy.float64, numpy.complex64, numpy.complex128)
     def s_atom_to_xt_array_numeric(self, o):
         """
         Render single numeric items into their corresponding array counterpart
         in R
         """
-        if isinstance(o, (int, long, numpy.int64, numpy.long)):
+        if isinstance(o, (int, long, numpy.int64, numpy.compat.long)):
             if rtypes.MIN_INT32 <= o <= rtypes.MAX_INT32:
                 # even though this type of data is 'long' it still fits into a
                 # normal integer. Good!
@@ -325,7 +325,8 @@ class RSerializer(object):
         @note: If o is multi-dimensional a tagged array is created. Also if o
                is of type TaggedArray.
         """
-        if o.dtype in (numpy.int64, numpy.long):
+        if o.dtype in (numpy.int64, numpy.compat.long):
+            # Note: use int instead of compat.long once Py2 is abandoned.
             if rtypes.MIN_INT32 <= o.min() and o.max() <= rtypes.MAX_INT32:
                 # even though this type of array is 'long' its values still
                 # fit into a normal int32 array. Good!
@@ -342,7 +343,7 @@ class RSerializer(object):
 
         # Note: R expects binary array data in Fortran order, so prepare this
         # accordingly:
-        self._buffer.write(o.tostring(order='F'))
+        self._buffer.write(o.tobytes(order='F'))
 
         # Update the array header:
         self.__s_update_xt_array_header(startPos, rTypeCode)

--- a/pyRserve/rtypes.py
+++ b/pyRserve/rtypes.py
@@ -277,8 +277,7 @@ if not PY3:
 # map r-types and some python types to typecodes used in the 'struct' module
 structMap = {
     XT_BOOL:          'b',
-    numpy.bool:       'b',
-    numpy.bool_:      'b',
+    bool:             'b',
     XT_BYTE:          'B',
     XT_INT:           'i',
     int:              'i',
@@ -289,9 +288,9 @@ structMap = {
     float:            'd',
     numpy.double:     'd',
     complex:          'd',
-    numpy.complex:    'd',
+    complex:          'd',
     numpy.complex128: 'd',
-    }
+}
 
 # mapping to determine overall type of message.
 DT_Map = {
@@ -303,24 +302,23 @@ DT_Map = {
 
 numpyMap = {
     XT_ARRAY_BOOL:     numpy.bool_,
-    #   XT_BYTE:           numpy.byte,
     XT_ARRAY_INT:      numpy.int32,
     XT_ARRAY_DOUBLE:   numpy.double,     # double float64
-    XT_ARRAY_CPLX:     numpy.complex,
+    XT_ARRAY_CPLX:     complex,
     XT_ARRAY_STR:      numpy.string_,
-    }
+}
 
 # also add the inverse mapping to it:
 for k, v in list(numpyMap.items()):
     numpyMap[v] = k
 
 # some manual additions for numpy variants:
-numpyMap[numpy.complex128] = XT_ARRAY_CPLX
-numpyMap[numpy.int32]      = XT_ARRAY_INT
-numpyMap[numpy.int64]      = XT_ARRAY_INT
-numpyMap[numpy.long]       = XT_ARRAY_INT
-numpyMap[numpy.str_]       = XT_ARRAY_STR
-numpyMap[numpy.unicode_]   = XT_ARRAY_STR
+numpyMap[numpy.complex128]  = XT_ARRAY_CPLX
+numpyMap[numpy.int32]       = XT_ARRAY_INT
+numpyMap[numpy.int64]       = XT_ARRAY_INT
+numpyMap[numpy.compat.long] = XT_ARRAY_INT
+numpyMap[numpy.str_]        = XT_ARRAY_STR
+numpyMap[numpy.unicode_]    = XT_ARRAY_STR
 
 
 atom2ArrMap = {
@@ -330,13 +328,10 @@ atom2ArrMap = {
     float:             XT_ARRAY_DOUBLE,
     numpy.double:      XT_ARRAY_DOUBLE,
     complex:           XT_ARRAY_CPLX,
-    numpy.complex:     XT_ARRAY_CPLX,
     numpy.complex128:  XT_ARRAY_CPLX,
     str:               XT_ARRAY_STR,
     numpy.str_:        XT_ARRAY_STR,
     numpy.string_:     XT_ARRAY_STR,
     numpy.unicode_:    XT_ARRAY_STR,
     bool:              XT_ARRAY_BOOL,
-    numpy.bool:        XT_ARRAY_BOOL,
-    numpy.bool_:       XT_ARRAY_BOOL,
-    }
+}

--- a/testing/test_rparser.py
+++ b/testing/test_rparser.py
@@ -160,12 +160,12 @@ def test_eval_integer_arrays():
     assert compareArrays(conn.r("c(55, -35)"), numpy.array([55.0, -35.0]))
     res = conn.r("c(55, -35)")
     assert isinstance(res, numpy.ndarray)
-    assert res.dtype == numpy.float
+    assert res.dtype == float
 
     # ### Create real integer arrays in R:
     res = conn.r('as.integer(c(1, 5))')
     assert compareArrays(res, numpy.array([1, 5]))
-    assert res.dtype in (numpy.int, numpy.int32)
+    assert res.dtype in (int, numpy.int32)
 
     # test via call to ident function with single argument:
     assert compareArrays(conn.r.ident(numpy.array([1, 5])),
@@ -212,7 +212,7 @@ def test_eval_float_arrays():
     assert compareArrays(conn.r("c(55.2, -35.7)"), numpy.array([55.2, -35.7]))
     res = conn.r("c(55.5, -35.5)")
     assert isinstance(res, numpy.ndarray)
-    assert res.dtype == numpy.float
+    assert res.dtype == float
 
     # test via call to ident function with single argument:
     assert compareArrays(conn.r.ident(numpy.array([1.7, 5.6])),
@@ -238,7 +238,7 @@ def test_eval_complex_arrays():
     res = conn.r("complex(real = 5.5, imaginary = 6.6)", atomicArray=True)
     assert compareArrays(res, numpy.array([(5.5+6.6j)]))
     assert isinstance(res, numpy.ndarray)
-    assert res.dtype == numpy.complex
+    assert res.dtype == complex
 
     # test via call to ident function with single argument:
     arr = numpy.array([(5.5+6.6j), (-3.0-6j)])
@@ -262,7 +262,7 @@ def test_eval_bool_arrays():
     """Test boolean arrays"""
     res = conn.r('TRUE', atomicArray=True)
     assert compareArrays(res, numpy.array([True]))
-    assert res.dtype == numpy.bool
+    assert res.dtype == bool
     assert compareArrays(conn.r('c(TRUE, FALSE)'), numpy.array([True, False]))
 
     # test via call to ident function with single argument:

--- a/testing/test_rparser.py
+++ b/testing/test_rparser.py
@@ -80,6 +80,8 @@ def test_eval_string_arrays():
                          numpy.array(['abc']))
     assert compareArrays(conn.r("c('abc', 'def')"),
                          numpy.array(['abc', 'def']))
+    assert compareArrays(conn.r("c('abc', NA, 'def')"),
+                         numpy.array(['abc', None, 'def']))
 
     # test via call to ident function with single argument:
     assert compareArrays(conn.r.ident(numpy.array(['abc', 'def'])),
@@ -264,6 +266,7 @@ def test_eval_bool_arrays():
     assert compareArrays(res, numpy.array([True]))
     assert res.dtype == bool
     assert compareArrays(conn.r('c(TRUE, FALSE)'), numpy.array([True, False]))
+    assert compareArrays(conn.r('c(TRUE, NA, FALSE)'), numpy.array([True, None, False]))
 
     # test via call to ident function with single argument:
     assert compareArrays(conn.r.ident(numpy.array([True, False, False])),

--- a/testing/testtools.py
+++ b/testing/testtools.py
@@ -6,8 +6,7 @@ import subprocess
 import time
 import socket
 
-from numpy import ndarray, float, float32, float64, complex, complex64, \
-    complex128
+from numpy import ndarray, float32, float64, complex64, complex128
 
 RSERVE_PATH = subprocess.check_output(
     ['R', '--vanilla', '--slave', '-e',


### PR DESCRIPTION
I know I'm wading into controversial water here, but there are cases where R's "NA" value is being converted into something unexpected in python. Specifically:

1. The first change addresses issue #21. In short, R `vector`s that contained `character` values and `NA` were causing `UnicodeDecodeErrors` as they were being parsed into `numpy` arrays. The change in `pyRserve/misc.py` now has the parser checking for R's `NA_character_` specifically and converting it to Python's `None`.

``` python
import pyRserve

conn = pyRserve.connect()

# Old behaivor
conn.eval("c('a', NA, 'b')") # => UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte

# New behaivor
conn.eval("c('a', NA, 'b')") # => array(['a', None, 'b'], dtype=object)

```

2. Converting an R `vector` that contains booleans and `NA` produces a python `numpy` array of integers and `None`. The `None` is expected, but the integers are a surprise. The change in `pyRserve/rparser.py` produces a numpy array of booleans and `None`. 

``` python
import pyRserve

conn = pyRserve.connect()

# Old behaivor
conn.eval("c(TRUE, NA, FALSE)") # => array([1, None, 0], dtype=object)

# New behaivor
conn.eval("c(TRUE, NA, FALSE)") # => array([True, None, False], dtype=object)
```

