### PR TITLE
Allow unix-socket connections

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -122,6 +122,26 @@ The approach could be:
    The connection to ``localhost:6311`` on the client machine will be forwarded to Rserve listening
    on ``localhost:6311`` on ``rservehost``.
 
+Variant 3: Connect to Rserve through a Unix socket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This option might be more flexible for concurrent/dynamic connections than variants 1 and 2 and
+is slightly more secure than variant 1 (and less than variant 2), as the Unix socket can only be
+accessed from within the server.
+
+To enable Unix sockets in Rserve a flag needs to be enabled::
+
+    R CMD Rserve --RS-socket /tmp/rserve.sock
+
+That socket can now be used from pyRserve::
+
+    >>> import pyRserve
+    >>> conn = pyRserve.connect(unix_socket='/tmp/rserve.sock')
+
+.. WARNING::
+    Just as in Variant 1, communication between pyRserve and Rserve is not encrypted.
+    The only additional security is that this socket cannot be accessed from the network,
+    but a user with access to the system can still sniff/manipulate your connection.
+
 
 Shutting down Rserve remotely
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyRserve/rconn.py
+++ b/pyRserve/rconn.py
@@ -106,8 +106,12 @@ class RConnector(object):
 
     def __repr__(self):
         txt = 'Closed handle' if self.isClosed else 'Handle'
-        return '<%s to Rserve on %s:%s>' % \
-               (txt, self.host or 'localhost', self.port)
+        if self.unix_socket:
+            return '<%s to Rserve on %s>' % \
+                   (txt, self.unix_socket)
+        else:
+            return '<%s to Rserve on %s:%s>' % \
+                   (txt, self.host or 'localhost', self.port)
 
     @property
     def isClosed(self):

--- a/pyRserve/rconn.py
+++ b/pyRserve/rconn.py
@@ -37,13 +37,14 @@ class OOBCallback(object):
         self.conn.oobCallback = self.old_callback
 
 
-def connect(host='', port=RSERVEPORT, atomicArray=False, defaultVoid=False,
+def connect(host='', port=RSERVEPORT, unix_socket=None, atomicArray=False, defaultVoid=False,
             oobCallback=_defaultOOBCallback):
     """Open a connection to an Rserve instance
     Params:
     - host: provide hostname where Rserve runs, or leave as empty string to
             connect to localhost
     - port: Rserve port number, defaults to 6311
+    - unix_socket: Unix Socket path (use in place of (host,port))
     - atomicArray:
             If True: when a result from an Rserve call is an array with
             a single element that single element
@@ -67,7 +68,7 @@ def connect(host='', port=RSERVEPORT, atomicArray=False, defaultVoid=False,
         # or '' were passed.
         host = 'localhost'
     assert port is not None, 'port number must be given'
-    return RConnector(host, port, atomicArray, defaultVoid, oobCallback)
+    return RConnector(host, port, unix_socket, atomicArray, defaultVoid, oobCallback)
 
 
 def checkIfClosed(func):
@@ -89,12 +90,13 @@ def checkIfClosed(func):
 
 class RConnector(object):
     """Provide a network connector to an Rserve process"""
-    def __init__(self, host, port, atomicArray, defaultVoid,
+    def __init__(self, host, port, unix_socket, atomicArray, defaultVoid,
                  oobCallback=_defaultOOBCallback):
         self.sock = None
         self.__closed = True
         self.host = host
         self.port = port
+        self.unix_socket = unix_socket
         self.atomicArray = atomicArray
         self.defaultVoid = defaultVoid
         self.oobCallback = oobCallback
@@ -112,12 +114,20 @@ class RConnector(object):
         return self.__closed
 
     def connect(self):
-        self.sock = socket.socket()
-        try:
-            self.sock.connect((self.host, self.port))
-        except socket.error:
-            raise RConnectionRefused('Connection denied, server not reachable '
-                                     'or not accepting connections')
+        if self.unix_socket:
+            self.sock = socket.socket(socket.AF_UNIX)
+            try:
+                self.sock.connect(self.unix_socket)
+            except socket.error:
+                raise RConnectionRefused('Connection denied, server not reachable '
+                                         'or not accepting connections')            
+        else:
+            self.sock = socket.socket()
+            try:
+                self.sock.connect((self.host, self.port))
+            except socket.error:
+                raise RConnectionRefused('Connection denied, server not reachable '
+                                         'or not accepting connections')
         time.sleep(0.2)
         hdr = self.sock.recv(1024)
         self.__closed = False


### PR DESCRIPTION
This PR enables connection to RServe through unix-socket files instead of ports.