### PR TITLE
Add standard build metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 
 upload-prep: docs
 	rm -f dist/*
-	python setup.py sdist bdist_wheel
+	python -m build
 	twine check dist/*
 
 upload: upload-prep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ sphinx
 pre-commit
 wheel
 twine
+build


### PR DESCRIPTION
Projects should contain [PEP 517](https://peps.python.org/pep-0517/) metadata.

If you want, you can move the metadata in setup.py into that file too, but no matter what, it needs to be there.