### PR TITLE
Migrate to numpy 2.0: replace removed APIs and add compat smoke tests

### DIFF
--- a/pyRserve/rparser.py
+++ b/pyRserve/rparser.py
@@ -538,7 +538,7 @@ class RParser(object):
                                        numpy.complex128)):
                     # convert into native python complex number:
                     data = complex(data)
-                elif isinstance(data, (numpy.string_, str)):
+                elif isinstance(data, (numpy.bytes_, str)):
                     # convert into native python string:
                     data = str(data)
                 elif isinstance(data, (bool, numpy.bool_)):

--- a/pyRserve/rserializer.py
+++ b/pyRserve/rserializer.py
@@ -291,14 +291,14 @@ class RSerializer(object):
         # Update the array header:
         self.__s_update_xt_array_header(startPos, rTypeCode)
 
-    @fmap(int, numpy.int32, long, numpy.int64, numpy.compat.long, float, complex,
+    @fmap(int, numpy.int32, long, numpy.int64, float, complex,
           numpy.float64, numpy.complex64, numpy.complex128)
     def s_atom_to_xt_array_numeric(self, o):
         """
         Render single numeric items into their corresponding array counterpart
         in R
         """
-        if isinstance(o, (int, long, numpy.int64, numpy.compat.long)):
+        if isinstance(o, (int, long, numpy.int64)):
             if rtypes.MIN_INT32 <= o <= rtypes.MAX_INT32:
                 # even though this type of data is 'long' it still fits into a
                 # normal integer. Good!
@@ -325,7 +325,7 @@ class RSerializer(object):
         @note: If o is multi-dimensional a tagged array is created. Also if o
                is of type TaggedArray.
         """
-        if o.dtype in (numpy.int64, numpy.compat.long):
+        if o.dtype in (numpy.int64,):
             # Note: use int instead of compat.long once Py2 is abandoned.
             if rtypes.MIN_INT32 <= o.min() and o.max() <= rtypes.MAX_INT32:
                 # even though this type of array is 'long' its values still

--- a/pyRserve/rtypes.py
+++ b/pyRserve/rtypes.py
@@ -267,7 +267,7 @@ VALID_R_TYPES = [
     XT_VECTOR_EXP, XT_NULL, XT_UNKNOWN, XT_RAW, XT_S4
 ]
 
-STRING_TYPES = [str, numpy.string_, numpy.str_]
+STRING_TYPES = [str, numpy.bytes_, numpy.str_]
 if not PY3:
     STRING_TYPES.append(unicode)  # noqa: F821      'unicode' unknown in Python3
 
@@ -305,7 +305,7 @@ numpyMap = {
     XT_ARRAY_INT:      numpy.int32,
     XT_ARRAY_DOUBLE:   numpy.double,     # double float64
     XT_ARRAY_CPLX:     complex,
-    XT_ARRAY_STR:      numpy.string_,
+    XT_ARRAY_STR:      numpy.bytes_,
 }
 
 # also add the inverse mapping to it:
@@ -316,9 +316,7 @@ for k, v in list(numpyMap.items()):
 numpyMap[numpy.complex128]  = XT_ARRAY_CPLX
 numpyMap[numpy.int32]       = XT_ARRAY_INT
 numpyMap[numpy.int64]       = XT_ARRAY_INT
-numpyMap[numpy.compat.long] = XT_ARRAY_INT
 numpyMap[numpy.str_]        = XT_ARRAY_STR
-numpyMap[numpy.unicode_]    = XT_ARRAY_STR
 
 
 atom2ArrMap = {
@@ -331,7 +329,6 @@ atom2ArrMap = {
     numpy.complex128:  XT_ARRAY_CPLX,
     str:               XT_ARRAY_STR,
     numpy.str_:        XT_ARRAY_STR,
-    numpy.string_:     XT_ARRAY_STR,
-    numpy.unicode_:    XT_ARRAY_STR,
+    numpy.bytes_:      XT_ARRAY_STR,
     bool:              XT_ARRAY_BOOL,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-numpy
+numpy>=2.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'pyRserve': ['version.txt'],
     },
     data_files=[('.', ['requirements.txt', 'requirements_dev.txt'])],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+    python_requires='>=3.9',
     install_requires=requirements,
     extras_require={
         'testing': requirements_testing

--- a/testing/test_numpy_compat.py
+++ b/testing/test_numpy_compat.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""
+Smoke tests that verify numpy >= 2.0 is installed and that the specific
+APIs used by pyRserve work as expected under numpy 2.0 semantics.
+
+These tests require no live Rserve connection.
+"""
+import struct
+
+import numpy
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Version guard
+# ---------------------------------------------------------------------------
+
+def test_numpy_version():
+    """numpy >= 2.0 is required; catches accidental downgrades in CI."""
+    major, minor = (int(x) for x in numpy.__version__.split('.')[:2])
+    assert (major, minor) >= (2, 0), (
+        "numpy >= 2.0 required, got %s" % numpy.__version__
+    )
+
+
+# ---------------------------------------------------------------------------
+# Removed aliases must be absent
+# ---------------------------------------------------------------------------
+
+def test_string_alias_removed():
+    """numpy.string_ was removed in 2.0 (replaced by numpy.bytes_)."""
+    assert not hasattr(numpy, 'string_'), (
+        "numpy.string_ still exists — downgrade to numpy < 2.0?"
+    )
+
+
+def test_compat_module_removed():
+    """numpy.compat (and numpy.compat.long) was removed in 2.0."""
+    assert not hasattr(numpy, 'compat'), (
+        "numpy.compat still exists — downgrade to numpy < 2.0?"
+    )
+
+
+def test_unicode_alias_removed():
+    """numpy.unicode_ was removed in 2.0 (replaced by numpy.str_)."""
+    assert not hasattr(numpy, 'unicode_'), (
+        "numpy.unicode_ still exists — downgrade to numpy < 2.0?"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Replacement types must be present
+# ---------------------------------------------------------------------------
+
+def test_replacement_types_exist():
+    """All scalar types used in rtypes.py / rparser.py after migration."""
+    for name in ('bytes_', 'bool_', 'str_',
+                 'int32', 'int64', 'float64', 'double', 'complex128'):
+        assert hasattr(numpy, name), "numpy.%s missing" % name
+
+
+# ---------------------------------------------------------------------------
+# frombuffer with every dtype used in rparser.py
+# ---------------------------------------------------------------------------
+
+def test_frombuffer_bool():
+    """xt_array_bool path: read numpy.bool_ from raw bytes."""
+    raw = struct.pack('4B', 1, 0, 1, 1)
+    arr = numpy.frombuffer(raw, dtype=numpy.bool_)
+    assert arr.dtype == numpy.bool_
+    assert list(arr) == [True, False, True, True]
+
+
+def test_frombuffer_int8_for_bool_na():
+    """bool-NA path: read int8 so that sentinel value 2 can be detected."""
+    raw = struct.pack('4b', 1, 0, 2, 1)
+    arr = numpy.frombuffer(raw, dtype=numpy.int8)
+    assert arr.dtype == numpy.int8
+    assert arr[2] == 2  # NA sentinel
+
+
+def test_frombuffer_int32():
+    """XT_ARRAY_INT path."""
+    raw = struct.pack('<3i', -1, 0, 300)
+    arr = numpy.frombuffer(raw, dtype=numpy.int32)
+    assert arr.dtype == numpy.int32
+    assert list(arr) == [-1, 0, 300]
+
+
+def test_frombuffer_float64():
+    """XT_ARRAY_DOUBLE path."""
+    raw = struct.pack('<2d', 1.5, -3.14)
+    arr = numpy.frombuffer(raw, dtype=numpy.float64)
+    assert arr.dtype == numpy.float64
+    assert abs(arr[1] - (-3.14)) < 1e-10
+
+
+def test_frombuffer_complex128():
+    """XT_ARRAY_CPLX path: pairs of doubles become complex128 values."""
+    raw = struct.pack('<4d', 1.0, 2.0, -3.0, 4.0)
+    arr = numpy.frombuffer(raw, dtype=numpy.complex128)
+    assert arr.dtype == numpy.complex128
+    assert arr[0] == complex(1.0, 2.0)
+    assert arr[1] == complex(-3.0, 4.0)
+
+
+# ---------------------------------------------------------------------------
+# astype casts used in rparser.py and rserializer.py
+# ---------------------------------------------------------------------------
+
+def test_astype_int8_to_object_with_none_assignment():
+    """
+    rparser.py bool-NA path: int8 -> object array, then write None at
+    positions where the NA sentinel (2) appears.
+    """
+    raw = struct.pack('4b', 1, 0, 2, 1)
+    arr = numpy.frombuffer(raw, dtype=numpy.int8).astype(object)
+    arr[arr == 2] = None
+    assert arr[0] == 1
+    assert arr[1] == 0
+    assert arr[2] is None
+    assert arr[3] == 1
+
+
+def test_astype_int64_to_int32():
+    """rserializer.py downcasts int64 arrays whose values fit in int32."""
+    arr64 = numpy.array([1, -2, 300], dtype=numpy.int64)
+    arr32 = arr64.astype(numpy.int32)
+    assert arr32.dtype == numpy.int32
+    assert list(arr32) == [1, -2, 300]
+
+
+# ---------------------------------------------------------------------------
+# Array serialisation helpers (tobytes / reshape in Fortran order)
+# ---------------------------------------------------------------------------
+
+def test_tobytes_fortran_order():
+    """rserializer.py writes arrays in column-major (Fortran) byte order."""
+    arr = numpy.array([[1, 2, 3], [4, 5, 6]], dtype=numpy.int32)
+    b = arr.tobytes(order='F')
+    # column-major: [1,4], [2,5], [3,6]
+    assert b == struct.pack('<6i', 1, 4, 2, 5, 3, 6)
+
+
+def test_reshape_fortran_order():
+    """rparser.py reconstructs multi-dim arrays sent in Fortran order."""
+    flat = numpy.array([1, 4, 2, 5, 3, 6], dtype=numpy.int32)
+    arr = flat.reshape((2, 3), order='F')
+    assert arr.shape == (2, 3)
+    assert arr[0, 0] == 1 and arr[1, 0] == 4  # first column
+    assert arr[0, 1] == 2 and arr[1, 1] == 5  # second column
+
+
+# ---------------------------------------------------------------------------
+# numpy.bytes_ replacing numpy.string_
+# ---------------------------------------------------------------------------
+
+def test_bytes_scalar_isinstance():
+    """numpy.bytes_ is usable for isinstance checks (replaces numpy.string_)."""
+    arr = numpy.array([b'hello', b'world'])
+    assert issubclass(arr.dtype.type, numpy.bytes_)
+    assert isinstance(arr[0], numpy.bytes_)
+
+
+def test_bytes_in_numpymap_lookup():
+    """dtype.type of a bytes array resolves to numpy.bytes_ (used in numpyMap)."""
+    arr = numpy.array([b'abc'])
+    assert arr.dtype.type is numpy.bytes_
+
+
+# ---------------------------------------------------------------------------
+# numpy 2.0 casting strictness: arange with float stop + integer dtype
+# ---------------------------------------------------------------------------
+
+def test_arange_integer_stop_works():
+    """The fixed pattern in test_rparser.py (integer division) must not raise."""
+    arr = numpy.arange(10, dtype=numpy.int32)
+    assert arr.dtype == numpy.int32
+    assert len(arr) == 10
+
+
+def test_ufunc_out_same_kind_casting():
+    """
+    numpy 2.0 changed the default ufunc out= casting from 'unsafe' to
+    'same_kind'.  Writing a float result into an integer out= array now
+    raises TypeError instead of silently truncating.
+    """
+    a = numpy.array([1.5])
+    out = numpy.array([0], dtype=numpy.int32)
+    with pytest.raises(TypeError):
+        numpy.add(a, 1.0, out=out)

--- a/testing/test_rparser.py
+++ b/testing/test_rparser.py
@@ -268,7 +268,7 @@ def test_large_objects(conn):
     Sent array back and forth btw Python and R before comparing them.
     """
     # make an integer (int32) array a little bit larger than 2**24
-    arr = numpy.arange(2**24 / 4 + 100, dtype=numpy.int32)
+    arr = numpy.arange(2**24 // 4 + 100, dtype=numpy.int32)
     conn.r.largearr = arr
     compareArrays(arr, conn.r.largearr)
 


### PR DESCRIPTION
- Replace numpy.string_ with numpy.bytes_ (removed in 2.0)
- Remove numpy.compat.long references (numpy.compat module removed in 2.0)
- Remove numpy.unicode_ references (removed in 2.0; numpy.str_ already covered it)
- Fix test_rparser.py: use integer division for numpy.arange stop argument
- Require numpy>=2.0 in requirements.txt; bump python_requires to >=3.9
- Add testing/test_numpy_compat.py: 18 standalone tests that verify the numpy version floor, assert removed aliases are absent, and smoke-test every frombuffer dtype, astype cast, tobytes/reshape order, and the numpy 2.0 same-kind ufunc out= casting rule